### PR TITLE
fix style error

### DIFF
--- a/core/src/main/scala/archery/Joined.scala
+++ b/core/src/main/scala/archery/Joined.scala
@@ -25,7 +25,7 @@ sealed trait Joined[A] extends Iterable[A] {
         val it1 = this.iterator
         val it2 = that.iterator
         while (it1.hasNext && it2.hasNext) {
-          if (it1.next != it2.next) return false
+          if (it1.next != it2.next) return false //scalastyle:off
         }
         it1.hasNext == it2.hasNext
       case _ =>


### PR DESCRIPTION
By default `return` fails Travis due to style errors.

We didn't have Travis on the last PR so I hadn't seen it. This is a simple fix.

(I could just disable the *return rule* but I like being forced to say that "yes, short-circuiting is worth an annoying comment" since I'm a bit perverse.)