### PR TITLE
Exclude archery.benchmark from coverage report.

### DIFF
--- a/benchmark/src/main/scala/archery/benchmark/Main.scala
+++ b/benchmark/src/main/scala/archery/benchmark/Main.scala
@@ -1,4 +1,5 @@
 package archery
+package benchmark
 
 import scala.collection.mutable.ArrayBuffer
 import scala.math.{min, max}

--- a/build.sbt
+++ b/build.sbt
@@ -64,3 +64,5 @@ lazy val benchmark =
     libraryDependencies ++= Seq(
       "ichi.bench" % "thyme" % "0.1.1" from "http://plastic-idolatry.com/jars/thyme-0.1.1.jar"),
     resolvers += Resolver.sonatypeRepo("releases")))
+
+ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages := "archery\\.benchmark\\..*"


### PR DESCRIPTION
This commit removes the benchmarks from coverage. We wouldn't
normally run "tests" against the benchmarking code.

This commit also standardizes the file structure a bit.

Move main.scala

Rename main.scala -> Main.scala, change package.

Exclude archery.benchmark from code coverage.

blah